### PR TITLE
fix: conditionals and repeats as keywords

### DIFF
--- a/languages/wgsl/highlights.scm
+++ b/languages/wgsl/highlights.scm
@@ -66,7 +66,7 @@
     "break"
     "continue"
     "continuing"
-] @repeat
+] @keyword.repeat
 
 [
     "if"
@@ -74,7 +74,7 @@
     "switch"
     "case"
     "default"
-] @conditional
+] @keyword.conditional
 
 [
     "&"


### PR DESCRIPTION
The highlighting for loops and branch statements didn't work properly because of the incomplete tree-sitter highlighting tag. 