### PR TITLE
feat: add initial language server support for wgsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 *.wasm
+grammars/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wgsl"
+version = "0.0.2"
+edition = "2021"
+
+[lib]
+path = "src/wgsl.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.0.6"

--- a/extension.json
+++ b/extension.json
@@ -1,9 +1,0 @@
-{
-  "name": "Wgsl",
-  "version": "0.0.1",
-  "authors": [
-    "Luan Santos <zed@luan.sh>"
-  ],
-  "description": "Wgsl language support for Zed",
-  "repository": "https://github.com/luan/zed-wgsl"
-}

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,15 @@
+id = "wgsl"
+name = "Wgsl"
+version = "0.0.2"
+schema_version = 1
+authors = ["Luan Santos <zed@luan.sh>", "xdk78 <xdk78888@gmail.com>"]
+description = "Wgsl language support for Zed"
+repository = "https://github.com/luan/zed-wgsl"
+
+[language_servers.wgsl]
+name = "Wgsl"
+language = "wgsl"
+
+[grammars.wgsl]
+repository = "https://github.com/szebniok/tree-sitter-wgsl"
+commit = "40259f3c77ea856841a4e0c4c807705f3e4a2b65"

--- a/grammars/wgsl.toml
+++ b/grammars/wgsl.toml
@@ -1,2 +1,0 @@
-repository = "https://github.com/szebniok/tree-sitter-wgsl"
-commit = "40259f3c77ea856841a4e0c4c807705f3e4a2b65"

--- a/src/wgsl.rs
+++ b/src/wgsl.rs
@@ -1,0 +1,29 @@
+use zed_extension_api::{self as zed, Result};
+
+struct WgslExtension;
+
+impl zed::Extension for WgslExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        // https://github.com/nolanderc/glasgow
+        // TODO: add auto download support
+        // TODO: add support for other language servers
+        let wgsl_lsp_cmd = worktree.which("glasgow");
+        let path = wgsl_lsp_cmd.ok_or_else(|| "glasgow must be in your path".to_string())?;
+
+        Ok(zed::Command {
+            command: path,
+            args: vec![],
+            env: Default::default(),
+        })
+    }
+}
+
+zed::register_extension!(WgslExtension);


### PR DESCRIPTION
- updated code base to use newer zed extension code structure
- added initial support for wgsl language server via https://github.com/nolanderc/glasgow 

Further testing and feedback is always welcome.