### PR TITLE
fix format of support languages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgsl"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 [lib]

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "wgsl"
 name = "Wgsl"
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = ["Luan Santos <zed@luan.sh>", "xdk78 <xdk78888@gmail.com>"]
 description = "Wgsl language support for Zed"
@@ -8,7 +8,7 @@ repository = "https://github.com/luan/zed-wgsl"
 
 [language_servers.glasgow]
 name = "Wgsl"
-language = "wgsl"
+languages = ["Wgsl"]
 
 [grammars.wgsl]
 repository = "https://github.com/szebniok/tree-sitter-wgsl"

--- a/test/shader.wgsl
+++ b/test/shader.wgsl
@@ -1,16 +1,12 @@
-@binding(0) @group(0) var<uniform> frame : u32;
+@binding(0) @group(0) var<uniform> frame: u32;
 @vertex
-fn vtx_main(@builtin(vertex_index) vertex_index : u32) -> @builtin(position) vec4f {
-  const pos = array(
-    vec2( 0.0,  0.5),
-    vec2(-0.5, -0.5),
-    vec2( 0.5, -0.5)
-  );
+fn vtx_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    const pos = array(vec2(0.0, 0.5), vec2(-0.5, -0.5), vec2(0.5, -0.5));
 
-  return vec4f(pos[vertex_index], 0, 1);
+    return vec4(pos[vertex_index], 0, 1);
 }
 
 @fragment
-fn frag_main() -> @location(0) vec4f {
-  return vec4(1, sin(f32(frame) / 128), 0, 1);
+fn frag_main() -> @location(0) vec4<f32> {
+    return vec4(1, sin(f32(frame) / 128), 0, 1);
 }


### PR DESCRIPTION
I found this extension is not working because the format of supported languages in `extension.toml` is `languages` according to the official document.
https://zed.dev/docs/extensions/languages#language-servers

So I made this PR to fix the issue. I'd appreciate it if you could check and merge the changes.

Thanks.